### PR TITLE
fixed EX2 exceptions and RRO for Negative inputs gt 127

### DIFF
--- a/FlexGripPlus_4.4/RTL/SMP/Pipeline/Execution/RRO/rro.vhd
+++ b/FlexGripPlus_4.4/RTL/SMP/Pipeline/Execution/RRO/rro.vhd
@@ -93,9 +93,18 @@ s_exp2_cmp			<= s_exp2_fixed_point xor s_exp2_sign_ext;
 
 s_exp2_adjs			<= std_logic_vector(unsigned(s_exp2_cmp) + 1) when input(31)='1' else s_exp2_cmp;
 
-s_exp2_final_result <= '1'&"11111111"&"00000000000000000000000" when s_too_big_exponent='1' else 
-						'1'&"00000000"&input(22 downto 0) when (input(30 downto 23)=X"FF" and input(31)='1') else 
-						'1'&input(30 downto 0) when (input(30 downto 23)=X"FF" and input(31)='0') else '0'&s_exp2_adjs(30 downto 0);
+-- s_exp2_final_result <= '1'&"11111111"&"00000000000000000000000" when s_too_big_exponent='1' else 
+-- 						'1'&"00000000"&input(22 downto 0) when (input(30 downto 23)=X"FF" and input(31)='1') else 
+-- 						'1'&input(30 downto 0) when (input(30 downto 23)=X"FF" and input(31)='0') else '0'&s_exp2_adjs(30 downto 0);
+
+s_exp2_final_result <=  '1'&"00001111"&"00000000000000000000000" when (input=X"7f800000") else  --+inf
+						'1'&"11110000"&"00000000000000000000000" when (input=X"ff800000") else  -- -inf
+						'1'&"11111111"&input(22 downto 0) when (input(30 downto 23)=X"FF" and input(22 downto 0)/="00000000000000000000000") else --NAN
+						'1'&"00001111"&"00000000000000000000000" when (s_too_big_exponent='1' and input(31)='0') else
+						'1'&"11110000"&"00000000000000000000000" when (s_too_big_exponent='1' and input(31)='1') else
+						'1'&"00000000"&"00000000000000000000000" when (input=X"00000000" or input(30 downto 23)=X"00")  else  -- Zero/subnorm
+						'0'&s_exp2_adjs(30 downto 0);
+
 
 
 Result <= s_exp2_final_result when selec_phase='1' else ieee_out_sin_cos;

--- a/FlexGripPlus_4.4/RTL/SMP/Pipeline/Execution/SFU/Components/SFU_Exceptions.vhd
+++ b/FlexGripPlus_4.4/RTL/SMP/Pipeline/Execution/SFU/Components/SFU_Exceptions.vhd
@@ -108,13 +108,30 @@ end process;
 IEEEEx2:process(i_data_input,i_oper_result)
 begin
 
-	if i_data_input(31)='1' and i_data_input(30 downto 23) = X"00" then -- -inf
-		s_ex2_exeption <= (others=>'0'); -- NaN +inf
-	elsif i_data_input(31)='1' and i_data_input(30 downto 23) = X"FF" then --+inf nan
-		s_ex2_exeption <='0'&i_data_input(30 downto 0);
+	if i_data_input(31)='1' then
+		if i_data_input(30 downto 23) = X"F0" and i_data_input(22 downto 0) = "00000000000000000000000" then -- input = -inf; output=0
+			s_ex2_exeption <= X"00000000";
+		elsif i_data_input(30 downto 23) = X"0F" and i_data_input(22 downto 0) = "00000000000000000000000" then -- input = +inf; output=+inf
+			s_ex2_exeption <= X"7f800000";
+		elsif i_data_input(30 downto 23) = X"FF" and i_data_input(22 downto 0) /= "00000000000000000000000" then -- input = NAN; output=NAN
+			s_ex2_exeption <= i_data_input;
+		elsif i_data_input(30 downto 23) = X"00" and i_data_input(22 downto 0) = "00000000000000000000000" then -- input = zero/+/-subnormal; output=+1
+			s_ex2_exeption <= X"3f800000";
+		else  -- input = normal ; output=2**-x
+			s_ex2_exeption <= i_oper_result;
+		end if;
 	else
-		s_ex2_exeption <=i_oper_result;
+		s_ex2_exeption <= i_oper_result;
 	end if;
+
+
+	-- if i_data_input(31)='1' and i_data_input(30 downto 23) = X"00" then -- -inf
+	-- 	s_ex2_exeption <= (others=>'0'); -- NaN +inf
+	-- elsif i_data_input(31)='1' and i_data_input(30 downto 23) = X"FF" then --+inf nan
+	-- 	s_ex2_exeption <='0'&i_data_input(30 downto 0);
+	-- else
+	-- 	s_ex2_exeption <=i_oper_result;
+	-- end if;
 
 end process;
 


### PR DESCRIPTION
This commit solves the issue ["sfu test error "](https://github.com/Jerc007/Open-GPGPU-FlexGrip-/issues/2#issue-1703395051). The RRO had partial exception resolution, and the exceptions in the SFU core. The new version already fixes such a problem.